### PR TITLE
Add makefile for gcc on linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+default:
+	g++ -std=c++11 -pthread -l dl *.cpp *.h -o amalgamate
+


### PR DESCRIPTION
Not much to it, and it isn't as flexible as some makefiles I've seen, but it works for me.
