### PR TITLE
Add support for #pragma once

### DIFF
--- a/Amalgamate.cpp
+++ b/Amalgamate.cpp
@@ -325,6 +325,8 @@ private:
     bool result;
     if (l1.replace ("#ifndef", "#define") == l2)
       result = false;
+    else if (l1 == "#pragmaonce")
+      result = false;
     else
       result = true;
 


### PR DESCRIPTION
The method canFileBeReincluded is supposed to return true if including it a second time is supposed to have an effect. For example, if we were #including some data that would go between a "{" and a "}", that would be valid to include multiple times. The method looks for a standard include guard, and returns false, indicating that re-including the file won't accomplish anything. This change adds looking for #pragma once as the first line in the file, in addition for looking for an include guard.
